### PR TITLE
Update SuspiciousSSPRActivity.yaml

### DIFF
--- a/Detections/EID-SSPR/SuspiciousSSPRActivity.yaml
+++ b/Detections/EID-SSPR/SuspiciousSSPRActivity.yaml
@@ -26,7 +26,7 @@ query: |
   let maxTimeBetweenSSPRandSigninInMinutes=7*24*60; // per Default max. difference is set to 7 Days
   AuditLogs
   | where TimeGenerated >= ago(SSPRLookback)
-  | where LoggedByService == "Self-service Password Management" and ResultDescription == "User submitted their user ID"
+  | where LoggedByService == "Self-service Password Management" and ResultDescription == "User completed all verification steps required to reset their password"
   | extend AccountType = tostring(TargetResources[0].type), UserPrincipalName = tostring(TargetResources[0].userPrincipalName),
     TargetResourceName = tolower(tostring(TargetResources[0].displayName)), SSPRSourceIP = tostring(InitiatedBy.user.ipAddress)
   | project UserPrincipalName, SSPRSourceIP, SSPRAttemptTime = TimeGenerated, CorrelationId
@@ -38,7 +38,7 @@ query: |
       | extend TrustedIP = tostring(IPAddress)
       | project UserPrincipalName, TrustedIP, SignInTime = TimeGenerated
   ) on UserPrincipalName
-  | where SSPRAttemptTime > SignInTime
+  | where SSPRAttemptTime > coalesce(SignInTime, datetime(0))
   | extend TimeDifferenceInMinutes= iif(SSPRSourceIP==TrustedIP,datetime_diff("Minute",SignInTime,SSPRAttemptTime), 0), Match=SSPRSourceIP==TrustedIP
   | where TimeDifferenceInMinutes >= -maxTimeBetweenSSPRandSigninInMinutes
   | summarize  SignInsFromTheSameIP=countif(Match), min(TimeDifferenceInMinutes) by UserPrincipalName, CorrelationId, SSPRAttemptTime, SSPRSourceIP   //SignInsFromTheSameIP=0 if no sign in came from the IP used for SSPR in the last maxTimeBetweenSSPRandSigninInMinutes

--- a/Detections/EID-SSPR/SuspiciousSSPRActivity.yaml
+++ b/Detections/EID-SSPR/SuspiciousSSPRActivity.yaml
@@ -53,5 +53,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled


### PR DESCRIPTION
ResultDescription == "User completed all verification steps required to reset their password" should reduce False/Benign Positives because we are now Post-Auth

SSPRAttemptTime > coalesce(SignInTime, datetime(0)) will also handle User with no SignIns in the given timerange.