### PR TITLE
Always use has for tags to allow more then one tag per watchlist entry

### DIFF
--- a/Detections/EID-AADConnect/AADConnect-SignInsOutsideServerIP.yaml
+++ b/Detections/EID-AADConnect/AADConnect-SignInsOutsideServerIP.yaml
@@ -1,4 +1,3 @@
-
 id: 12531591-8392-4b4c-b117-485216bbf577
 name: Successful sign-ins from valid AAD connector account outside of whitelisted IP address from WatchList
 description: |
@@ -42,5 +41,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Detections/EID-AADConnect/AADConnect-SignInsOutsideServerIP.yaml
+++ b/Detections/EID-AADConnect/AADConnect-SignInsOutsideServerIP.yaml
@@ -24,9 +24,9 @@ relevantTechniques:
   - T1528
 query: |
   let AADCServer = (_GetWatchlist('HighValueAssets')
-      | where ['Tags'] == "Azure AD Connect" | project ['IP Address']);
+      | where ['Tags'] has "Azure AD Connect" | project ['IP Address']);
   let AADConnectorAcc = (_GetWatchlist('ServiceAccounts')
-      | where ['Tags'] == "Azure AD Connect" | project AccountObjectId = ['Service AAD Object Id']);
+      | where ['Tags'] has "Azure AD Connect" | project AccountObjectId = ['Service AAD Object Id']);
   union isfuzzy=true AADNonInteractiveUserSignInLogs, SigninLogs
   // AADC APIs: AADSync = "cb1056e2-e479-49de-ae31-7812af012ed8", AAD Connect v2 = 6eb59a73-39b2-4c23-a70f-e2e3ce8965b1
   | where (UserId in (AADConnectorAcc) or AppId == "cb1056e2-e479-49de-ae31-7812af012ed8" or AppId == "6eb59a73-39b2-4c23-a70f-e2e3ce8965b1") and IPAddress !in (AADCServer)

--- a/Detections/EID-AADConnect/AADConnectorAccount-AADActivitiesWithEnrichedInformation.yaml
+++ b/Detections/EID-AADConnect/AADConnectorAccount-AADActivitiesWithEnrichedInformation.yaml
@@ -1,4 +1,3 @@
-
 id: 5f1bdb2f-5622-4ab2-bc4b-96cc9ff480c8
 name: Activities from AAD connector account with enrichment of IdentityInfo
 description: |
@@ -37,11 +36,7 @@ entityMappings:
       - identifier: FullName
         columnName: AccountCustomEntity
   - entityType: IP
-    fieldMappings:        
+    fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity       
-version: 1.0.0
-
-
-
-
+        columnName: IPCustomEntity
+version: 1.0.1

--- a/Detections/EID-AADConnect/AADConnectorAccount-AADActivitiesWithEnrichedInformation.yaml
+++ b/Detections/EID-AADConnect/AADConnectorAccount-AADActivitiesWithEnrichedInformation.yaml
@@ -20,9 +20,9 @@ relevantTechniques:
   - T1078
 query: |
   let AADConnectorAcc = (_GetWatchlist('ServiceAccounts')
-      | where ['Tags'] == "Azure AD Connect" | project AccountObjectId = ['Service AAD Object Id']);
+      | where ['Tags'] has "Azure AD Connect" | project AccountObjectId = ['Service AAD Object Id']);
   let AADCServer = (_GetWatchlist('HighValueAssets')
-      | where ['Tags'] == "Azure AD Connect" | project ['IP Address']);    
+      | where ['Tags'] has "Azure AD Connect" | project ['IP Address']);    
   AuditLogs
   | extend ActorAccountObjectId = tostring(parse_json(tostring(InitiatedBy.user)).id)
   | extend ActorAccountIPAddress = tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)

--- a/Detections/EID-AADConnect/AADConnectorAccount-AddedTAPorChangedPassword.yaml
+++ b/Detections/EID-AADConnect/AADConnectorAccount-AddedTAPorChangedPassword.yaml
@@ -1,4 +1,3 @@
-
 id: a091a0c0-2397-4dd9-a3f0-ea8a3d2dded2
 name: Added temporary access pass or changed password of Azure AD connector account
 description: |
@@ -36,5 +35,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: AccountCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Detections/EID-AADConnect/AADConnectorAccount-AddedTAPorChangedPassword.yaml
+++ b/Detections/EID-AADConnect/AADConnectorAccount-AddedTAPorChangedPassword.yaml
@@ -22,7 +22,7 @@ relevantTechniques:
   - T1078
 query: |
   let AADConnectorAcc = (_GetWatchlist('ServiceAccounts')
-      | where ['Tags'] == "Azure AD Connect" | project AccountObjectId = ['Service AAD Object Id']);
+      | where ['Tags'] has "Azure AD Connect" | project AccountObjectId = ['Service AAD Object Id']);
   AuditLogs
     | extend TargetUpn = tolower(tostring(TargetResources[0].userPrincipalName))
     | extend TargetId = tostring(TargetResources[0].id)

--- a/Detections/EID-AADConnect/AADConnectorAccount-OutsideOfWatchList.yaml
+++ b/Detections/EID-AADConnect/AADConnectorAccount-OutsideOfWatchList.yaml
@@ -1,6 +1,6 @@
 id: 86e9ba6f-d1ed-48b8-a849-c26f77db8c1b
 name: Detection of Microsoft Entra Connect accounts outside of WatchLists
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled
 description: List of objects with Directory role membership to "Directory Synchronization" or naming similar to Microsoft Entra Connect account which aren't stored in the WatchList was found. Indicator of creating AAD connector account as backdoor.
 severity: Medium


### PR DESCRIPTION
* Changed from "equals" (==) to "has" to allow for more than one tag per watchlist item without resulting in False Positive
* Trim whitespaces
* Apply default YAML formatting